### PR TITLE
do not rst_stream_ when in closed

### DIFF
--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -708,9 +708,8 @@ closed(timeout, _,
                      Stream#stream_state.response_body,
                      Stream#stream_state.response_trailers}),
     {stop, normal, Stream};
-closed(cast, {send_t, _Trailers},
-    #stream_state{}) ->
-    keep_state_and_data;
+closed(cast, {send_t, _Trailers}, #stream_state{} = Stream) ->
+    {stop, normal, Stream};
 closed(_, _,
        #stream_state{}=Stream) ->
     rst_stream_(?STREAM_CLOSED, Stream);

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -708,6 +708,9 @@ closed(timeout, _,
                      Stream#stream_state.response_body,
                      Stream#stream_state.response_trailers}),
     {stop, normal, Stream};
+closed(cast, {send_t, _Trailers},
+    #stream_state{}) ->
+    keep_state_and_data;
 closed(_, _,
        #stream_state{}=Stream) ->
     rst_stream_(?STREAM_CLOSED, Stream);

--- a/test/http2_spec_3_5_SUITE.erl
+++ b/test/http2_spec_3_5_SUITE.erl
@@ -68,7 +68,7 @@ sends_incomplete_connection_preface(_Config) ->
     {ok, _ConnectionInfo} = ssl:connection_information(Socket),
 
     %% There's a 5 second timeout before the socket will be closed
-    ssl:recv(Socket, 0, 5000),
+    ssl:recv(Socket, 0, 6000),
 
     {error, _} = ssl:send(Socket, <<"something else">>),
     {error, _} = ssl:connection_information(Socket),


### PR DESCRIPTION
This solves:
https://github.com/tsloughter/grpcbox/issues/51

Not sure if this is the correct way to solve it. But I think it gives a clear picture of why the health check failed.


In my testing I have seen that it sometimes work. I guess it is when it is in half_closed_local when send_t arrive.