### PR TITLE
Window size fixes

### DIFF
--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -587,6 +587,10 @@ route_frame({H, _Payload},
                         ok;
                     NewIWS ->
                         Delta = NewIWS - OldIWS,
+                        case Delta > 0 of
+                            true -> send_window_update(self(), Delta);
+                            false -> ok
+                        end,
                         h2_stream_set:update_all_recv_windows(Delta, Streams)
                 end,
 

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -656,7 +656,9 @@ route_frame(F={H=#frame_header{
                     recv_data(Stream, F),
                     {next_state,
                      connected,
-                     Conn};
+                     Conn#connection{
+                       recv_window_size=CRWS-L
+                      }};
                 %% Either
                 %% {false, auto, true} or
                 %% {false, manual, _DoesntMatter}

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -586,7 +586,7 @@ route_frame({H, _Payload},
                     undefined ->
                         ok;
                     NewIWS ->
-                        Delta = OldIWS - NewIWS,
+                        Delta = NewIWS - OldIWS,
                         h2_stream_set:update_all_recv_windows(Delta, Streams)
                 end,
 

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -575,7 +575,7 @@ update_all_recv_windows_subset(Delta, PeerSubset) ->
 update_all_send_windows(Delta, Streams) ->
     Streams#stream_set{
       theirs=update_all_send_windows_subset(Delta, Streams#stream_set.theirs),
-      mine=update_all_recv_windows_subset(Delta, Streams#stream_set.mine)
+      mine=update_all_send_windows_subset(Delta, Streams#stream_set.mine)
      }.
 
 update_all_send_windows_subset(Delta, PeerSubset) ->

--- a/test/flow_control_SUITE.erl
+++ b/test/flow_control_SUITE.erl
@@ -26,7 +26,7 @@ init_per_testcase(
     PreChatterConfig =
         [
          {stream_callback_mod, server_connection_receive_window},
-         {initial_window_size, ?DEFAULT_INITIAL_WINDOW_SIZE * 2},
+         {initial_window_size, ?DEFAULT_INITIAL_WINDOW_SIZE},
          {flow_control, manual}
         |Config],
     chatterbox_test_buddy:start(PreChatterConfig);


### PR DESCRIPTION
- Fix conn recv window delta calculation on SETTING ACK
- Send WINDOW_UPDATE on SETTINGS acknowledgement when the window size has been increased
- Decrease conn recv window on received data, it was never reduced and kept growing
- Fix stream send window size update on SETTINGS (fixes joedevivo/chatterbox#134).