### PR TITLE
Improve performance by not waiting in sock:recv

### DIFF
--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1556,7 +1556,7 @@ handle_socket_data(Data,
                       buffer=Buffer
                      }=Conn) ->
     More =
-        case sock:recv(Socket, 0, 1) of %% fail fast
+        case sock:recv(Socket, 0, 0) of %% fail fast
             {ok, Rest} ->
                 Rest;
             %% It's not really an error, it's what we want


### PR DESCRIPTION
A 1ms timeout was used in sock:recv. This has a big impact on
performance. By immediately continuing processing if no data is
available, the number of messages that can be handled per second
improves from less than 200 per connection to thousands or tens of
thousands (depending on resources).