### PR TITLE
Don't set END_STREAM if there are trailers to send

### DIFF
--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -724,8 +724,14 @@ s_send_what_we_can(SWS, MFS, #active_stream{}=Stream) ->
         case MaxToSend > QueueSize of
             true ->
                 Flags = case Stream#active_stream.body_complete of
-                         true -> ?FLAG_END_STREAM;
-                         false -> 0
+                            true ->
+                                case Stream of
+                                    #active_stream{trailers=undefined} ->
+                                        ?FLAG_END_STREAM;
+                                    _ ->
+                                        0
+                                end;
+                            false -> 0
                         end,
                 %% We have the power to send everything
                 {{#frame_header{


### PR DESCRIPTION
Calling h2_connection:send_trailers ends up setting body_complete
fo the stream to true. But it can be that the h2_connection is
still in the process of sending data if a larger data has been
given to send_body. Then the END_STREAM flag is falsely set already
at the last DATA frame.

This commit fixes the issue by not setting the END_STREAM flag on
the DATA frame if there are trailers defined to be sent.

Fixes tsloughter/grpcbox#63.