### PR TITLE
Fix RST_STREAM when stream closing

### DIFF
--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -719,7 +719,7 @@ send_trailers(State, Trailers, Stream=#stream_state{connection=Pid,
     h2_connection:actually_send_trailers(Pid, StreamId, Trailers),
     case State of
         half_closed_remote ->
-            {next_state, closed, Stream};
+            {next_state, closed, Stream, 0};
         open ->
             {next_state, half_closed_local, Stream}
     end.


### PR DESCRIPTION
Fixes an issue where a RST_STREAM message is sent each time a
stream is closed. As was the case with the code prior to hpack
dynamic table concurrency fixes, sending trailers in
half_closed_remote state should transfer the state to closed with
a timeout action.

This is an alternative solution to #7 that fixes tsloughter/grpcbox#51 the way it used to be before (https://github.com/tsloughter/chatterbox/pull/5/files#diff-d3c0445427befca915a9897b50d4d356e5e360fd3bac4f0a773a4dd639771b3dR573).