### PR TITLE
Add terminate callback to h2_stream

### DIFF
--- a/src/chatterbox_static_stream.erl
+++ b/src/chatterbox_static_stream.erl
@@ -9,7 +9,8 @@
          on_receive_headers/2,
          on_send_push_promise/2,
          on_receive_data/2,
-         on_end_stream/1
+         on_end_stream/1,
+         terminate/1
         ]).
 
 -record(cb_static, {
@@ -146,6 +147,9 @@ on_end_stream(State=#cb_static{connection_pid=ConnPid,
     end,
 
     {ok, State}.
+
+terminate(_State) ->
+    ok.
 
 %% Internal
 

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -97,6 +97,10 @@
             CallbackState :: callback_state()) ->
     {ok, NewState :: callback_state()}.
 
+-callback terminate(
+            CallbackState :: callback_state()) ->
+    any().
+
 %% Public API
 -spec start_link(
         StreamId :: stream_id(),
@@ -764,9 +768,13 @@ handle_event(_, _Event, State) ->
 code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
 
-terminate(normal, _StateName, _State) ->
+terminate(normal, _StateName, _State=#stream_state{callback_mod=CB,
+                                                  callback_state=CallbackState}) ->
+    callback(CB, terminate, [], CallbackState),
     ok;
-terminate(_Reason, _StateName, _State) ->
+terminate(_Reason, _StateName, _State=#stream_state{callback_mod=CB,
+                                                  callback_state=CallbackState}) ->
+    callback(CB, terminate, [], CallbackState),
     ok.
 
 -spec rst_stream_(error_code(), state()) ->

--- a/test/double_body_handler.erl
+++ b/test/double_body_handler.erl
@@ -9,7 +9,8 @@
          on_receive_headers/2,
          on_send_push_promise/2,
          on_receive_data/2,
-         on_end_stream/1
+         on_end_stream/1,
+         terminate/1
         ]).
 
 -record(state, {conn_pid :: pid(),
@@ -49,3 +50,6 @@ on_end_stream(State=#state{conn_pid=ConnPid,
                             [{send_end_stream, false}]),
     h2_connection:send_body(ConnPid, StreamId, <<"BodyPart2">>),
     {ok, State}.
+
+terminate(_State) ->
+    ok.

--- a/test/echo_handler.erl
+++ b/test/echo_handler.erl
@@ -9,7 +9,8 @@
          on_receive_headers/2,
          on_send_push_promise/2,
          on_receive_data/2,
-         on_end_stream/1
+         on_end_stream/1,
+         terminate/1
         ]).
 
 -record(state, {conn_pid :: pid(),
@@ -50,3 +51,6 @@ on_end_stream(State=#state{conn_pid=ConnPid,
     h2_connection:send_headers(ConnPid, StreamId, ResponseHeaders),
     h2_connection:send_body(ConnPid, StreamId, Buffer),
     {ok, State}.
+
+terminate(_State) ->
+    ok.

--- a/test/flow_control_handler.erl
+++ b/test/flow_control_handler.erl
@@ -11,7 +11,8 @@
          on_receive_headers/2,
          on_send_push_promise/2,
          on_receive_data/2,
-         on_end_stream/1
+         on_end_stream/1,
+         terminate/1
         ]).
 
 -record(state, {conn_pid :: pid(),
@@ -52,3 +53,6 @@ on_end_stream(State=#state{conn_pid=ConnPid,
     timer:sleep(200),
     h2_connection:send_body(ConnPid, StreamId, crypto:strong_rand_bytes(?SEND_BYTES)),
     {ok, State}.
+
+terminate(_State) ->
+    ok.

--- a/test/peer_test_handler.erl
+++ b/test/peer_test_handler.erl
@@ -9,7 +9,8 @@
          on_receive_headers/2,
          on_send_push_promise/2,
          on_receive_data/2,
-         on_end_stream/1
+         on_end_stream/1,
+         terminate/1
         ]).
 
 -record(state, {conn_pid :: pid(),
@@ -53,3 +54,6 @@ on_end_stream(State=#state{conn_pid=ConnPid,
     h2_connection:send_headers(ConnPid, StreamId, ResponseHeaders),
     h2_connection:send_body(ConnPid, StreamId, Body),
     {ok, State}.
+
+terminate(_State) ->
+    ok.

--- a/test/server_connection_receive_window.erl
+++ b/test/server_connection_receive_window.erl
@@ -7,7 +7,8 @@
          on_receive_headers/2,
          on_send_push_promise/2,
          on_receive_data/2,
-         on_end_stream/1
+         on_end_stream/1,
+         terminate/1
         ]).
 
 -record(cb_static, {
@@ -34,3 +35,6 @@ on_receive_data(Bin, State)->
 on_end_stream(State) ->
     ct:pal("on_end_stream(~p)", [State]),
     {ok, State}.
+
+terminate(_State) ->
+    ok.

--- a/test/server_stream_receive_window.erl
+++ b/test/server_stream_receive_window.erl
@@ -7,7 +7,8 @@
          on_receive_headers/2,
          on_send_push_promise/2,
          on_receive_data/2,
-         on_end_stream/1
+         on_end_stream/1,
+         terminate/1
         ]).
 
 -record(cb_static, {
@@ -34,3 +35,6 @@ on_receive_data(_Bin, State)->
 on_end_stream(State) ->
     ct:pal("on_end_stream(~p)", [State]),
     {ok, State}.
+
+terminate(_State) ->
+    ok.


### PR DESCRIPTION
If the stream terminates without receiving END_STREAM, no signal
would be sent to the user. Adding terminate callback in order to
not end up with hanging streams.

Fix for tsloughter/grpcbox#72 on the chatterbox side.