### PR TITLE
prevent crash on window update with closed socket

### DIFF
--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1008,7 +1008,7 @@ handle_event(_, {send_window_update, Size},
                 recv_window_size=CRWS,
                 socket=Socket
                 }=Conn) ->
-    ok = h2_frame_window_update:send(Socket, Size, 0),
+    h2_frame_window_update:send(Socket, Size, 0),
     {keep_state,
      Conn#connection{
        recv_window_size=CRWS+Size


### PR DESCRIPTION
The window update sending was assumed to always succeed. This is not the case when the socket has been closed. For example, when there are messages in the gen_statem message queue then operations can be run on an already closed socket.

The fix ignores the socket error and just continues, similar to what other socket send operations seem to do in this module. Eventually the tcp_closed/tcp_error event should be handled by handle_event and the connection go down.