### PR TITLE
remove write concurrency from stream set tables

### DIFF
--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1184,10 +1184,13 @@ spawn_data_receiver(Socket, Streams, Flow) ->
     h2_stream_set:set_socket_send_window_size(?DEFAULT_INITIAL_WINDOW_SIZE, Streams),
     Type = h2_stream_set:stream_set_type(Streams),
     ConnDetails = get('__h2_connection_details'),
-    spawn_link(fun() ->
-                       put('__h2_connection_details', ConnDetails),
-                       receive_data(Socket, Streams, Connection, Flow, Type, true, hpack:new_context())
-               end).
+    spawn_opt(
+        fun() ->
+            put('__h2_connection_details', ConnDetails),
+            receive_data(Socket, Streams, Connection, Flow, Type, true, hpack:new_context())
+        end,
+        [link, {fullsweep_after, 0}]
+    ).
 
 
 receive_data(Socket, Streams, Connection, Flow, Type, First, Decoder) ->

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -124,7 +124,7 @@ start_link(StreamId, Streams, Connection, CallbackModule, CallbackOptions) ->
                            Connection,
                            CallbackModule,
                            CallbackOptions],
-                          []).
+                          [{hibernate_after, 10000}]).
 
 
 -spec start(
@@ -143,7 +143,7 @@ start(StreamId, Streams, Connection, CallbackModule, CallbackOptions) ->
                            Connection,
                            CallbackModule,
                            CallbackOptions],
-                          []).
+                          [{hibernate_after, 10000}]).
 
 send_event(Pid, Event) ->
     gen_statem:cast(Pid, Event).

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -30,7 +30,7 @@
 
      connection :: pid(),
 
-     table = ets:new(?MODULE, [public, {keypos, 2}, {read_concurrency, true}, {write_concurrency, true}]) :: ets:tab(),
+     table = ets:new(?MODULE, [public, {keypos, 2}, {read_concurrency, true}]) :: ets:tab(),
      %% Streams initiated by this peer
      %% mine :: peer_subset(),
      %% Streams initiated by the other peer


### PR DESCRIPTION
There's a rather significant memory overhead for ets tables that are `{read+write_concurrency, true}`.

Starting with a plain erlang runtime, making 100k empty ets tables...

```
| Read Concurrency | Write Concurrency | Total Mem | Ets Mem | std alloc Mem |
|------------------+-------------------+-----------+---------+---------------|
| baseline         | baseline          | 112 mb    | 2 mb    | 427 kb        |
| false            | false             | 130 mb    | 26 mb   | 427 kb        |
| true             | false             | 142 mb    | 26 mb   | 12 mb         |
| false            | true              | 225 mb    | 106 mb  | 12 mb         |
| true             | true              | 1 Gb      | 106 mb  | 736 mb
|
```
We've been running this on a couple servers that maintain a few thousand incoming connections of bidirectional streams, and maintain a few outgoing connections with a few thousand bidirectional streams. 