### PR TITLE
Fix h2_client:stop()

### DIFF
--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -805,7 +805,7 @@ handle_event(_, {send_frame, Frame},
     Binary = h2_frame:to_binary(Frame),
     socksend(Conn, Binary),
     {keep_state, Conn};
-handle_event(stop, _StateName,
+handle_event(_, stop,
             #connection{}=Conn) ->
     go_away(stop, 0, Conn);
 handle_event({call, From}, streams,


### PR DESCRIPTION
Previously calling h2_client:stop() would result in "h2_connection received unexpected event of type cast : stop" in the error log. It seems that the stop event was overlooked when gen_fsm was replaced with gen_statem.