### PR TITLE
Avoid send window update for every data received

### DIFF
--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -161,6 +161,7 @@
     update_trailers/2,
     update_data_queue/3,
     decrement_recv_window/2,
+    increment_recv_window/2,
     recv_window_size/1,
     decrement_socket_recv_window/2,
     increment_socket_recv_window/2,
@@ -1167,6 +1168,16 @@ decrement_recv_window(
      };
 decrement_recv_window(_, S) ->
     S.
+
+increment_recv_window(
+  L,
+  #active_stream{recv_window_size=RWS}=Stream
+) ->
+  Stream#active_stream{
+    recv_window_size=RWS+L
+   };
+increment_recv_window(_, S) ->
+  S.
 
 decrement_socket_recv_window(L, #stream_set{atomics = Atomics}) ->
     atomics:sub_get(Atomics, ?RECV_WINDOW_SIZE, L).

--- a/test/flow_control_SUITE.erl
+++ b/test/flow_control_SUITE.erl
@@ -70,7 +70,7 @@ exceed_server_connection_receive_window(_Config) ->
     ok.
 
 exceed_server_stream_receive_window(_Config) ->
-    Client = send_n_bytes(65),
+    Client = send_n_bytes(32767),
 
     %% First, pull off the window update frame we got on stream 0,
     [WindowUpdate] = http2c:wait_for_n_frames(Client, 0, 1),


### PR DESCRIPTION
Use the same logic of connection window update to avoid send window update for every data received.