### PR TITLE
Client-side fixes

### DIFF
--- a/src/chatterbox_h2_connection.erl
+++ b/src/chatterbox_h2_connection.erl
@@ -489,11 +489,18 @@ connected(info, send_all_we_can, State=#connection{send_all_we_can_timer=undefin
 connected(info, actually_send_all_we_can, State) ->
     %% time to do the thing, but do it in a spawn so we don't block
     %% the connection
-    {_, Ref} = spawn_monitor(fun() ->
+    {_, Ref} = proc_lib:spawn_opt(fun() ->
                           chatterbox_h2_stream_set:send_all_we_can(State#connection.streams)
-                  end),
+                 end,
+                 [monitor]),
     {keep_state, State#connection{send_all_we_can_timer=Ref}};
-connected(info, {'DOWN', Ref, process, _, _}, State=#connection{send_all_we_can_timer=Ref}) ->
+connected(info, {'DOWN', Ref, process, _, Reason}, State=#connection{send_all_we_can_timer=Ref}) ->
+    case Reason of
+        normal -> ok;
+        shutdown -> ok;
+        {shutdown, _} -> ok;
+        _ -> error({send_all_we_can_crashed, Reason})
+    end,
     %% its done, decide if we need to schedule another one
     case State#connection.missed_send_all_we_can of
         true ->

--- a/src/chatterbox_h2_connection.erl
+++ b/src/chatterbox_h2_connection.erl
@@ -341,7 +341,7 @@ send_request(Streams, Headers, Body) ->
 
 -spec send_request(chatterbox_h2_stream_set:stream_set(), hpack:headers(), binary(), atom(), list()) -> ok.
 send_request(Streams, Headers, Body, CallbackMod, CallbackOpts) ->
-    gen_server:call(chatterbox_h2_stream_set:connection(Streams), {new_stream, CallbackMod, CallbackOpts, Headers, Body, [], self()}).
+    gen_server:call(chatterbox_h2_stream_set:connection(Streams), {new_stream, CallbackMod, CallbackOpts, Headers, Body, [], self()}, infinity).
 
 -spec send_ping(chatterbox_h2_stream_set:stream_set()) -> ok.
 send_ping(Streams) ->
@@ -370,7 +370,7 @@ is_push(Streams) ->
     end.
 
 new_stream(Streams, Headers, Body) ->
-    gen_server:call(chatterbox_h2_stream_set:connection(Streams), {new_stream, undefined, [], Headers, Body, [], self()}).
+    gen_server:call(chatterbox_h2_stream_set:connection(Streams), {new_stream, undefined, [], Headers, Body, [], self()}, infinity).
 
 %% @doc `new_stream/6' accepts Headers so they can be sent within the connection process
 %% when a stream id is assigned. This ensures that another process couldn't also have
@@ -378,15 +378,15 @@ new_stream(Streams, Headers, Body) ->
 %% results in the server closing the connection when it gets headers for the lower id stream.
 -spec new_stream(chatterbox_h2_stream_set:stream_set(), module(), term(), hpack:headers(), send_opts(), pid()) -> {stream_id(), pid()} | {error, error_code()}.
 new_stream(Streams, CallbackMod, CallbackOpts, Headers, Opts, NotifyPid) ->
-    gen_server:call(chatterbox_h2_stream_set:connection(Streams), {new_stream, CallbackMod, CallbackOpts, Headers, Opts, NotifyPid}).
+    gen_server:call(chatterbox_h2_stream_set:connection(Streams), {new_stream, CallbackMod, CallbackOpts, Headers, Opts, NotifyPid}, infinity).
 
 -spec new_stream(chatterbox_h2_stream_set:stream_set(), module(), term(), hpack:headers(), any(), send_opts(), pid()) -> {stream_id(), pid()} | {error, error_code()}.
 new_stream(Streams, CallbackMod, CallbackOpts, Headers, Body, Opts, NotifyPid) ->
-    gen_server:call(chatterbox_h2_stream_set:connection(Streams), {new_stream, CallbackMod, CallbackOpts, Headers, Body, Opts, NotifyPid}).
+    gen_server:call(chatterbox_h2_stream_set:connection(Streams), {new_stream, CallbackMod, CallbackOpts, Headers, Body, Opts, NotifyPid}, infinity).
 
 -spec send_promise(chatterbox_h2_stream_set:stream_set(), stream_id(), hpack:headers()) -> {stream_id(), pid()} | {error, error_code()}.
 send_promise(Streams, StreamId, Headers) ->
-    gen_server:call(chatterbox_h2_stream_set:connection(Streams), {send_promise, StreamId, Headers, self()}).
+    gen_server:call(chatterbox_h2_stream_set:connection(Streams), {send_promise, StreamId, Headers, self()}, infinity).
 
 -spec get_response(chatterbox_h2_stream_set:stream_set(), stream_id()) ->
                           {ok, {hpack:headers(), iodata(), iodata()}}

--- a/src/chatterbox_h2_connection.erl
+++ b/src/chatterbox_h2_connection.erl
@@ -1253,7 +1253,7 @@ receive_data(Socket, Streams, Connection, Flow, Type, First, Decoder) ->
                                             %% Make window size great again if we've used up half our buffer
                                             #settings{
                                                   initial_window_size=IWS
-                                                 } = chatterbox_h2_stream_set:get_peer_settings(Streams),
+                                                 } = chatterbox_h2_stream_set:get_self_settings(Streams),
                                             case {chatterbox_h2_stream_set:decrement_socket_recv_window(L, Streams), IWS div 2} of
                                                 {Rem, Half} when Rem < Half ->
                                                     %% refill the window

--- a/src/chatterbox_h2_connection.erl
+++ b/src/chatterbox_h2_connection.erl
@@ -1287,8 +1287,13 @@ receive_data(Socket, Streams, Connection, Flow, Type, First, Decoder) ->
                                                                             Streams)
                                     end,
                                     receive_data(Socket, Streams, Connection, Flow, Type, false, Decoder);
-                                StreamType ->
-                                    go_away_(?PROTOCOL_ERROR, list_to_binary(io_lib:format("data on ~p stream ~p", [StreamType, Header#frame_header.stream_id])), Socket, Streams),
+                                closed ->
+                                    %% As per RFC-9113 a peer MAY send GO_AWAY when receiving data on a closed stream,
+                                    %% or ignore it. It MUST ignore received data frames for a while after sending RST_STREAM.
+                                    %% The easiest way of doing this is to never send GO_AWAY in this case.
+                                    receive_data(Socket, Streams, Connection, Flow, Type, false, Decoder);
+                                idle ->
+                                    go_away_(?PROTOCOL_ERROR, list_to_binary(io_lib:format("data on idle stream ~p", [Header#frame_header.stream_id])), Socket, Streams),
                                     Connection ! {go_away, ?PROTOCOL_ERROR}
                             end
                     end;

--- a/src/chatterbox_h2_stream.erl
+++ b/src/chatterbox_h2_stream.erl
@@ -3,8 +3,8 @@
 
 %% Public API
 -export([
-         start_link/5,
-         start/5,
+         start_link/6,
+         start/6,
          send_event/2,
          send_pp/2,
          send_data/2,
@@ -49,6 +49,7 @@
           stream_id = undefined :: stream_id(),
           streams :: chatterbox_h2_stream_set:stream_set(),
           connection = undefined :: undefined | pid(),
+          notify_pid :: pid(),
           socket = undefined :: chatterbox_sock:socket(),
           state = idle :: stream_state_name(),
           incoming_frames = queue:new() :: queue:queue(chatterbox_h2_frame:frame()),
@@ -113,15 +114,17 @@
         StreamId :: stream_id(),
         Streams :: chatterbox_h2_stream_set:stream_set(),
         Connection :: pid(),
+        NotifyPid :: pid(),
         CallbackModule :: module(),
         CallbackOptions :: list()
                   ) ->
                         {ok, pid()} | ignore | {error, term()}.
-start_link(StreamId, Streams, Connection, CallbackModule, CallbackOptions) ->
+start_link(StreamId, Streams, Connection, NotifyPid, CallbackModule, CallbackOptions) ->
     gen_statem:start_link(?MODULE,
                           [StreamId,
                            Streams,
                            Connection,
+                           NotifyPid,
                            CallbackModule,
                            CallbackOptions],
                           [{hibernate_after, 10000}]).
@@ -131,16 +134,18 @@ start_link(StreamId, Streams, Connection, CallbackModule, CallbackOptions) ->
         StreamId :: stream_id(),
         Streams :: chatterbox_h2_stream_set:stream_set(),
         Connection :: pid(),
+        NotifyPid :: pid(),
         CallbackModule :: module(),
         CallbackOptions :: list()
                   ) ->
                         {ok, pid()} | ignore | {error, term()}.
-start(StreamId, Streams, Connection, CallbackModule, CallbackOptions) ->
+start(StreamId, Streams, Connection, NotifyPid, CallbackModule, CallbackOptions) ->
     gen_statem:start(?MODULE,
                           [link_connection,
                            StreamId,
                            Streams,
                            Connection,
+                           NotifyPid,
                            CallbackModule,
                            CallbackOptions],
                           [{hibernate_after, 10000}]).
@@ -193,15 +198,18 @@ init([
       StreamId,
       Streams,
       ConnectionPid,
+      NotifyPid,
       CB=undefined,
       _CBOptions
      ]) ->
+    monitor_notify_pid(NotifyPid),
     erlang:monitor(process, ConnectionPid),
     {ok, idle, #stream_state{
                   callback_mod=CB,
                   stream_id=StreamId,
                   streams=Streams,
                   connection=ConnectionPid,
+                  notify_pid=NotifyPid,
                   socket=chatterbox_h2_stream_set:socket(Streams),
                   type=chatterbox_h2_stream_set:stream_set_type(Streams)
                  }};
@@ -209,9 +217,11 @@ init([
       StreamId,
       Streams,
       ConnectionPid,
+      NotifyPid,
       CB,
       CBOptions
      ]) ->
+    monitor_notify_pid(NotifyPid),
     erlang:monitor(process, ConnectionPid),
     %% don't block stream init with a slow callback init
     {ok, idle, #stream_state{
@@ -219,6 +229,7 @@ init([
                   stream_id=StreamId,
                   streams=Streams,
                   connection=ConnectionPid,
+                  notify_pid=NotifyPid,
                   socket=chatterbox_h2_stream_set:socket(Streams),
                   type=chatterbox_h2_stream_set:stream_set_type(Streams)
                  }, [{next_event, info, {init_callback, CBOptions}}]};
@@ -227,6 +238,7 @@ init([
       _StreamId,
       _Streams,
       ConnectionPid,
+      _NotifyPid,
       _CB,
       _CBOptions
      ]=Args) ->
@@ -752,13 +764,12 @@ half_closed_local(Type, Event, State) ->
     handle_event(Type, Event, State).
 
 closed(timeout, _,
-       #stream_state{stream_id=StreamId, streams=Streams}=StreamState) ->
+       #stream_state{stream_id=StreamId, streams=Streams, notify_pid=NotifyPid}=StreamState) ->
     try 
         Stream = chatterbox_h2_stream_set:get(StreamId, Streams),
         Type = chatterbox_h2_stream_set:stream_set_type(Streams),
         case chatterbox_h2_stream_set:type(Stream) of
             active ->
-                NotifyPid = chatterbox_h2_stream_set:notify_pid(Stream),
                 GarbageOnEnd = chatterbox_h2_stream_set:get_garbage_on_end(Streams),
                 Response =
                     case {Type, GarbageOnEnd} of
@@ -792,6 +803,8 @@ closed(cast,
   #stream_state{connection=_Pid,
                 stream_id=_StreamId}=Stream) ->
    {keep_state,Stream#stream_state{response_trailers=Headers}, 0};
+closed(info, {'DOWN', _Ref, process, Pid, _Reason}, #stream_state{notify_pid=Pid}) ->
+    keep_state_and_data;
 closed(_T, _E,
        #stream_state{}=Stream) ->
     rst_stream_(?STREAM_CLOSED, Stream);
@@ -836,6 +849,8 @@ handle_event(cast, {rst_stream, ErrorCode}, State=#stream_state{}) ->
     rst_stream_(ErrorCode, State);
 handle_event(info, {'DOWN', _Ref, process, Pid, Reason}, #stream_state{connection=Pid}) ->
     {stop, Reason};
+handle_event(info, {'DOWN', _Ref, process, Pid, _Reason}, #stream_state{notify_pid=Pid}=StreamState) ->
+    rst_stream_(?CANCEL, StreamState);
 handle_event(cast, Event, State=#stream_state{callback_mod=CB,
                                               callback_state=CallbackState}) when CB /= undefined ->
     CallbackState1 = CB:handle_info(Event, CallbackState),
@@ -978,3 +993,11 @@ validate_pseudos(_, DoneWithPseudos, _Found) ->
       DoneWithPseudos)
         andalso
         no_upper_names(DoneWithPseudos).
+
+monitor_notify_pid(undefined) ->
+    undefined;
+monitor_notify_pid(NotifyPid) when is_pid(NotifyPid) ->
+    case application:get_env(chatterbox, cancel_stream_on_down, false) of
+        true -> erlang:monitor(process, NotifyPid);
+        false -> undefined
+    end.

--- a/src/chatterbox_h2_stream_set.erl
+++ b/src/chatterbox_h2_stream_set.erl
@@ -17,6 +17,7 @@
 -define(MY_ACTIVE_COUNT, 5).
 -define(THEIR_ACTIVE_COUNT, 6).
 -define(LAST_SEND_ALL_WE_CAN_STREAM_ID, 7).
+-define(SEND_ROUND_ROBIN_END, 8).
 
 -record(
    stream_set,
@@ -24,13 +25,13 @@
      %% Type determines which streams are mine, and which are theirs
      type :: client | server,
 
-     atomics = atomics:new(7, []),
+     atomics = atomics:new(8, []),
 
      socket :: chatterbox_sock:socket(),
 
      connection :: pid(),
 
-     table = ets:new(?MODULE, [public, {keypos, 2}, {read_concurrency, true}]) :: ets:tab(),
+     table = ets:new(?MODULE, [ordered_set, public, {keypos, 2}, {read_concurrency, true}]) :: ets:tab(),
      %% Streams initiated by this peer
      %% mine :: peer_subset(),
      %% Streams initiated by the other peer
@@ -848,11 +849,10 @@ update_my_max_active(NewMax, Streams) ->
 send_all_we_can(Streams) ->
     PeerSettings = get_peer_settings(Streams),
     MaxFrameSize = PeerSettings#settings.max_frame_size,
-    
-    %% TODO be smarter about where we start off (remember where we last stopped, etc),
-    %% inspect priorities, etc
+
     Last = atomics:get(Streams#stream_set.atomics, ?LAST_SEND_ALL_WE_CAN_STREAM_ID),
-    case ets:select(Streams#stream_set.table, ets:fun2ms(fun(AS=#active_stream{id=Id, queued_data=D, trailers=T}) when Id > Last andalso ((not is_atom(D)) orelse T /= undefined)  -> AS end), 20) of
+    End = atomics:get(Streams#stream_set.atomics, ?SEND_ROUND_ROBIN_END),
+    case ets:select(Streams#stream_set.table, ets:fun2ms(fun(AS=#active_stream{id=Id, queued_data=D, trailers=T}) when Id > Last andalso Id < End andalso ((not is_atom(D)) orelse T /= undefined)  -> AS end), 20) of
         '$end_of_table' ->
             ok;
         Res ->
@@ -864,9 +864,13 @@ send_all_we_can(Streams) ->
 
     case Last == Last2 of
         true ->
-            %% we didn't run out of send window, so now traverse the
-            %% streams we have not inspected yet
-            case ets:select(Streams#stream_set.table, ets:fun2ms(fun(AS=#active_stream{id=Id, queued_data=D, trailers=T}) when Id =< Last andalso ((not is_atom(D)) orelse T /= undefined)  -> AS end), 20) of
+            %% we didn't run out of send window, so now wrap around the round robin and start from 0 again
+            TheirNext = atomics:get(Streams#stream_set.atomics, ?THEIR_NEXT_AVAILABLE_STREAM_ID),
+            MyNext = atomics:get(Streams#stream_set.atomics, ?MY_NEXT_AVAILABLE_STREAM_ID),
+            NewEnd = max(TheirNext, MyNext),
+            atomics:put(Streams#stream_set.atomics, ?SEND_ROUND_ROBIN_END, NewEnd),
+            atomics:put(Streams#stream_set.atomics, ?LAST_SEND_ALL_WE_CAN_STREAM_ID, 0),
+            case ets:select(Streams#stream_set.table, ets:fun2ms(fun(AS=#active_stream{id=Id, queued_data=D, trailers=T}) when Id < NewEnd andalso ((not is_atom(D)) orelse T /= undefined)  -> AS end), 20) of
                 '$end_of_table' ->
                     ok;
                 Res2 ->

--- a/src/chatterbox_h2_stream_set.erl
+++ b/src/chatterbox_h2_stream_set.erl
@@ -379,7 +379,7 @@ get_peer_settings(StreamSet) ->
     try hd(ets:lookup(StreamSet#stream_set.table, peer_settings)) of
         #connection_settings{settings=locked} ->
             timer:sleep(1),
-            get_self_settings(StreamSet);
+            get_peer_settings(StreamSet);
         #connection_settings{settings=Settings} ->
             Settings
     catch error:badarg ->

--- a/src/chatterbox_h2_stream_set.erl
+++ b/src/chatterbox_h2_stream_set.erl
@@ -317,6 +317,7 @@ new_stream(
                                   StreamId,
                                   StreamSet,
                                   self(),
+                                  NotifyPid,
                                   CBMod,
                                   CBOpts
                                  );
@@ -325,6 +326,7 @@ new_stream(
                                   StreamId,
                                   StreamSet,
                                   StreamSet#stream_set.connection,
+                                  NotifyPid,
                                   CBMod,
                                   CBOpts
                                  )

--- a/src/chatterbox_h2_stream_set.erl
+++ b/src/chatterbox_h2_stream_set.erl
@@ -896,7 +896,8 @@ send_what_we_can(StreamId, StreamFun, Streams) ->
     MaxFrameSize = PeerSettings#settings.max_frame_size,
 
 
-    NewConnSendWindowSize = s_send_what_we_can(MaxFrameSize,
+    {_, NewConnSendWindowSize} =
+    s_send_what_we_can(MaxFrameSize,
                        StreamId,
                        StreamFun,
                        Streams),
@@ -916,15 +917,15 @@ c_send_what_we_can(MFS, {[], CC}, StreamSet) ->
             c_send_what_we_can(MFS, Res, StreamSet)
     end;
 c_send_what_we_can(MFS, {[S|Streams], CC}, StreamSet) ->
-    NewSWS = s_send_what_we_can(MFS, stream_id(S), fun(Stream) -> Stream end, StreamSet),
-    case NewSWS =< 0 of
-        true ->
-            %% If we hit =< 0, done
-            %% track where we stopped
+    case s_send_what_we_can(MFS, stream_id(S), fun(Stream) -> Stream end, StreamSet) of
+        {out_of_window, NewSWS} ->
+            %% We did not send this stream, we're done. (NewSWS was rewinded)
+            %% Track that we stopped on this stream, so we can continue on the next,
+            %% when we get more window.
             atomics:put(StreamSet#stream_set.atomics, ?LAST_SEND_ALL_WE_CAN_STREAM_ID, stream_id(S)),
             NewSWS;
-        false ->
-            %% Otherwise, try sending on the next stream
+        {in_window, _NewSWS} ->
+            %% try sending on the next stream,
             c_send_what_we_can(MFS, {Streams, CC}, StreamSet)
     end.
 
@@ -933,7 +934,7 @@ c_send_what_we_can(MFS, {[S|Streams], CC}, StreamSet) ->
                          StreamId :: stream_id(),
                          StreamFun :: fun((stream()) -> stream()),
                          StreamSet :: stream_set()) ->
-                                integer().
+                                {in_window | out_of_window, integer()}.
 s_send_what_we_can(MFS, StreamId, StreamFun0, Streams) ->
     StreamFun = 
     fun(#active_stream{queued_data=Data, trailers=undefined}=Stream) when is_atom(Data) ->
@@ -1043,7 +1044,7 @@ s_send_what_we_can(MFS, StreamId, StreamFun0, Streams) ->
     case update(StreamId, fun(Stream0) -> StreamFun(StreamFun0(Stream0)) end, Streams) of
         ok ->
             NewSWS = socket_send_window_size(Streams),
-            NewSWS;
+            {in_window, NewSWS};
         {ok, {BytesSent, OldStream, Actions}} ->
             NewSWS = decrement_socket_send_window(BytesSent, Streams),
             case NewSWS < 0 of
@@ -1052,11 +1053,12 @@ s_send_what_we_can(MFS, StreamId, StreamFun0, Streams) ->
                     %% we delved too deep, and too greedily
                     %% try to roll things back
                     ets:insert(Streams#stream_set.table, StreamFun0(OldStream)),
-                    increment_socket_send_window(BytesSent, Streams);
+                    RestoredSWS = increment_socket_send_window(BytesSent, Streams),
+                    {out_of_window, RestoredSWS};
                 false ->
                     %% ok, its now safe to apply these actions
                     apply_stream_actions(Actions),
-                    NewSWS
+                    {in_window, NewSWS}
             end
     end.
 

--- a/test/chatterbox_test_buddy.erl
+++ b/test/chatterbox_test_buddy.erl
@@ -72,13 +72,17 @@ start(Config) ->
 
     ct:pal("Started: ~p", [List]),
 
+    ProtocolCallbackOpts = proplists:get_value(protocol_callback_opts, Config,
+                                              []),
+    ProtocolCallbackMod = proplists:get_value(protocol_callback_mod, Config,
+                                              chatterbox_ranch_protocol),
     {ok, _RanchPid} =
         ranch:start_listener(
           chatterbox_ranch_protocol,
           ranch_ssl,
           #{ socket_opts => [{alpn_preferred_protocols, [<<"h2">>]},{port, 8081}|proplists:get_value(ssl_options, Settings)] },
-          chatterbox_ranch_protocol,
-          []),
+          ProtocolCallbackMod,
+          ProtocolCallbackOpts),
     Config.
 
 ssl(SSLBool, Config) ->

--- a/test/client_server_SUITE.erl
+++ b/test/client_server_SUITE.erl
@@ -11,7 +11,8 @@ all() ->
      {group, default_handler},
      {group, peer_handler},
      {group, double_body_handler},
-     {group, echo_handler}
+     {group, echo_handler},
+     {group, client}
     ].
 
 groups() -> [{default_handler,  [complex_request,
@@ -21,7 +22,8 @@ groups() -> [{default_handler,  [complex_request,
              {peer_handler, [get_peer_in_handler]},
              {double_body_handler, [send_body_opts]},
              {echo_handler, [echo_body,
-                             large_body]}
+                             large_body]},
+             {client, [extra_data_on_closed_stream]}
             ].
 
 init_per_suite(Config) ->
@@ -42,6 +44,11 @@ init_per_group(peer_handler, Config) ->
     chatterbox_test_buddy:start(NewConfig);
 init_per_group(echo_handler, Config) ->
     NewConfig = [{stream_callback_mod, echo_handler}|Config],
+    chatterbox_test_buddy:start(NewConfig);
+init_per_group(client, Config) ->
+    ProtocolCallbackOpts = [{defer_data_until_rst_stream, true}],
+    NewConfig = [{protocol_callback_opts, ProtocolCallbackOpts},
+                 {protocol_callback_mod, http2s}|Config],
     chatterbox_test_buddy:start(NewConfig);
 init_per_group(_, Config) -> Config.
 
@@ -276,4 +283,43 @@ large_body(_Config) ->
                              end, DataFrames),
     io:format("response: ~p~n", [ResponseData]),
     ?assertEqual(size(Body), iolist_size(ResponseData)),
+    ok.
+
+extra_data_on_closed_stream(_Config) ->
+    {ok, StreamSet} = chatterbox_h2_client:start_link(),
+    RequestHeaders =
+        [
+         {<<":method">>, <<"GET">>},
+         {<<":path">>, <<"/index.html">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
+        ],
+    {ok, StreamId} = chatterbox_h2_client:send_request(StreamSet, RequestHeaders, <<"body">>),
+    Stream = chatterbox_h2_stream_set:get(StreamId, StreamSet),
+    Pid = chatterbox_h2_stream_set:stream_pid(Stream),
+    chatterbox_h2_stream:rst_stream(Pid, ?CANCEL),
+    receive
+        {'END_STREAM', StreamId} ->
+            ok
+    after 5000 ->
+            ct:fail(timeout)
+    end,
+    %% Wait for the http2s to receive the rst_stream, upon which it
+    %% should send its deferred data, so that the h2_connection client
+    %% will receive data on a closed stream.  We should still be able
+    %% to send new requests on the connection.
+    %% Chek that the h2_connection is still alive.
+    H2ConnectionPid = chatterbox_h2_stream_set:connection(StreamSet),
+    MRef = monitor(process, H2ConnectionPid),
+    {ok, StreamId2} = chatterbox_h2_client:send_request(StreamSet, RequestHeaders, <<>>),
+    receive
+        {'DOWN', MRef, _, _, Reason} ->
+            error({connection_terminated, Reason});
+        {'END_STREAM', StreamId2} ->
+            {ok, {_ResponseHeaders, _ResponseBody, _Trailers}} =
+                chatterbox_h2_client:get_response(StreamSet, StreamId2)
+    end,
     ok.

--- a/test/client_server_SUITE.erl
+++ b/test/client_server_SUITE.erl
@@ -5,6 +5,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -compile([export_all]).
+-compile([nowarn_export_all]).
 
 all() ->
     [
@@ -12,7 +13,8 @@ all() ->
      {group, peer_handler},
      {group, double_body_handler},
      {group, echo_handler},
-     {group, client}
+     {group, client_for_server_with_deferred_response},
+     {group, client_for_server_with_no_end_stream}
     ].
 
 groups() -> [{default_handler,  [complex_request,
@@ -23,7 +25,9 @@ groups() -> [{default_handler,  [complex_request,
              {double_body_handler, [send_body_opts]},
              {echo_handler, [echo_body,
                              large_body]},
-             {client, [extra_data_on_closed_stream]}
+             {client_for_server_with_deferred_response,
+              [extra_data_on_closed_stream]},
+             {client_for_server_with_no_end_stream, [can_monitor_owner]}
             ].
 
 init_per_suite(Config) ->
@@ -45,8 +49,14 @@ init_per_group(peer_handler, Config) ->
 init_per_group(echo_handler, Config) ->
     NewConfig = [{stream_callback_mod, echo_handler}|Config],
     chatterbox_test_buddy:start(NewConfig);
-init_per_group(client, Config) ->
+init_per_group(client_for_server_with_deferred_response, Config) ->
     ProtocolCallbackOpts = [{defer_data_until_rst_stream, true}],
+    NewConfig = [{protocol_callback_opts, ProtocolCallbackOpts},
+                 {protocol_callback_mod, http2s}|Config],
+    chatterbox_test_buddy:start(NewConfig);
+init_per_group(client_for_server_with_no_end_stream, Config) ->
+    application:set_env(chatterbox, cancel_stream_on_down, true),
+    ProtocolCallbackOpts = [{no_end_stream, true}],
     NewConfig = [{protocol_callback_opts, ProtocolCallbackOpts},
                  {protocol_callback_mod, http2s}|Config],
     chatterbox_test_buddy:start(NewConfig);
@@ -56,6 +66,7 @@ init_per_testcase(_, Config) ->
     Config.
 
 end_per_group(_, Config) ->
+    application:set_env(chatterbox, cancel_stream_on_down, false),
     chatterbox_test_buddy:stop(Config),
     ok.
 
@@ -323,3 +334,46 @@ extra_data_on_closed_stream(_Config) ->
                 chatterbox_h2_client:get_response(StreamSet, StreamId2)
     end,
     ok.
+
+can_monitor_owner(_Config) ->
+    ct:timetrap({seconds, 10}),
+    {ok, StreamSet} = chatterbox_h2_client:start_link(),
+    RequestHeaders =
+        [
+         {<<":method">>, <<"GET">>},
+         {<<":path">>, <<"/index.html">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
+        ],
+    TestProcess = self(),
+    {Pid, MRef} =
+        proc_lib:spawn_opt(
+          fun() ->
+                  {ok, StreamId} = chatterbox_h2_client:send_request(
+                                     StreamSet, RequestHeaders, <<"body">>),
+                  TestProcess ! {client_stream_id, StreamId},
+                  receive ok_terminate -> ok end
+          end,
+          [monitor]),
+    receive
+        {client_stream_id, StreamId} ->
+            await(fun() -> http2s:is_stream(StreamId) == true end),
+            Pid ! ok_terminate,
+            receive
+                {'DOWN', MRef, _, _, _} ->
+                    await(fun() -> http2s:is_stream(StreamId) == false end)
+            end
+    end,
+    ok.
+
+await(Condition) ->
+    case Condition() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(10),
+            await(Condition)
+    end.

--- a/test/h2_stream_set_SUITE.erl
+++ b/test/h2_stream_set_SUITE.erl
@@ -1,0 +1,408 @@
+-module(h2_stream_set_SUITE).
+
+-include("http2.hrl").
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-compile([export_all, nowarn_export_all]).
+
+all() ->
+    [
+     {group, x}
+    ].
+
+groups() -> [{x, [send_window_size_after_settings_in_handshake,
+                  scheduling_when_out_of_window]}
+            ].
+
+init_per_suite(Config) ->
+    Config.
+
+init_per_group(_, Config) ->
+    Config.
+
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, Config) ->
+    Config.
+
+end_per_group(_, _Config) ->
+    ok.
+
+end_per_suite(_Config) ->
+    ok.
+
+send_window_size_after_settings_in_handshake(_Config) ->
+    {ok, #{server_addr := Addr, server_port := Port}=ServerInfo} =
+        start_server(),
+    {ok, #{sock := _CSock, streams := Streams}=Conn} =
+        connect_to_server(Addr, Port),
+    ok = handshake_as_if_exchanged_settings(65535, Conn),
+    ct:pal("handshaked, streams=~n  ~p~n", [extract_stream_set(Streams)]),
+    timer:sleep(1000),
+    close_connection(Conn, ServerInfo),
+    ok.
+
+extract_stream_set(StreamSet) ->
+  #{stream_set => StreamSet,
+    counters => maps:from_list(
+                  [{{I, K}, atomics:get(element(3, StreamSet), I)}
+                   || {K, I} <- [{recv_window_size, 1},
+                                 {send_window_size, 2},
+                                 {my_next_available_stream_id, 3},
+                                 {their_next_available_stream_id, 4},
+                                 {my_active_count, 5},
+                                 {their_active_count, 6},
+                                 {last_send_all_we_can_stream_ID, 7}]]),
+    table => ets:tab2list(element(6, StreamSet))}.
+
+scheduling_when_out_of_window() ->
+    [{timetrap, {seconds, 15}}].
+
+scheduling_when_out_of_window(_Config) ->
+    {ok, #{server_addr := Addr, server_port := Port}=ServerInfo} =
+        start_server(),
+    ct:pal("Addr,Port=~p,~p", [Addr, Port]),
+    {ok, #{sock := _CSock, streams := Streams}=Conn} =
+        connect_to_server(Addr, Port),
+    ok = handshake_as_if_exchanged_settings(65535, Conn),
+    ct:pal("handshaked: Stream:~n  ~p", [extract_stream_set(Streams)]),
+
+    %% Trigger window update, as if we'd gotten it from the from server
+    %% h2_stream_set:increment_socket_send_window(10, Streams)
+    simulate_window_update(10, 0, Streams, ServerInfo),
+
+    %% This is an infinite stream
+    {_StreamPid1, StreamId1, _} = chatterbox_h2_stream_set:new_stream(
+                                   next, self(), undefined, [], Streams),
+    ok = send_headers_and_data_from_client(Conn, StreamId1,
+                                           <<"hello world 12345678">>),
+
+    %% Inidcate that there's room to send 5 more bytes in addition to
+    %% the 10 bytes above, but the entire text to send is 20 bytes, so
+    %% there should still be more data to send on this stream:
+    simulate_window_update(5, 0, Streams, ServerInfo),
+
+    %% Now, before all data has been sent on stream 1, do start some more
+    %% streams each with 20 more bytes of data to send
+
+    AllStreamIds = [1, 3, 5, 7, 9, 11], % client stream ids are odd-numbered
+    MoreStreamIds = tl(AllStreamIds), % send on the rest of the streams:
+    lists:foreach(
+        fun(_) ->
+            {_StreamPidN, StreamIdN, _} =
+                    chatterbox_h2_stream_set:new_stream(next, self(), undefined, [],
+                                             Streams),
+            ok = send_headers_and_data_from_client(Conn, StreamIdN,
+                                                   <<"hello world 12345678">>),
+            simulate_window_update(20, 0, Streams, ServerInfo)
+        end, MoreStreamIds),
+
+    %% The server has received data for all streams 1..11
+    %%
+    %% If everything is good, the first stream's data should have made
+    %% it over to the server side by now:
+    %% initially 10 bytes, then 5more bytes, then the rest as the window size
+    %% was increased when each new stream sent more data.
+    %%
+    %% However, without the fix, stream 1 will get starved for sending,
+    %% while all of subsequently started streams' data will make it through.
+    Events = get_await_data_for_streams(ServerInfo, AllStreamIds, []),
+    show_event_data(Events),
+    ?assertEqual(20, iolist_size(get_event_data_payloads(StreamId1, Events))),
+    close_connection(Conn, ServerInfo),
+    ok.
+
+get_await_data_for_streams(ServerInfo, StreamIdsToAwait, Events) ->
+    MoreEvents = get_clear_events(ServerInfo),
+    AllEvents = Events ++ MoreEvents,
+    StreamIdsReceived =
+        [StreamId || #{type := data,
+                       stream_id := StreamId} <- AllEvents],
+    case sets:is_equal(sets:from_list(StreamIdsToAwait),
+                       sets:from_list(StreamIdsReceived)) of
+        true ->
+            AllEvents;
+        false ->
+            %% We asked the server too early, some data could be in transit
+            %% over TCP to the server still. Ask again soon:
+            timer:sleep(10),
+            get_await_data_for_streams(ServerInfo, StreamIdsToAwait, AllEvents)
+    end.
+
+show_event_data(Events) ->
+    StreamIds = lists:usort([StreamId || #{stream_id := StreamId} <- Events]),
+    Rows = [begin
+                Bytes = get_event_data_payloads(StreamId, Events),
+                io_lib:format("  ~3w     ~3p: ~p~n",
+                              [StreamId, iolist_size(Bytes), Bytes])
+            end
+            || StreamId <- StreamIds],
+    ct:pal("  Stream  Bytes received server side~n"
+           "  ----------------------------------~n"
+           "~s~n"
+           "  ----------------------------------~n"
+           " Events received on the server side: ~p~n",
+           [Rows, Events]).
+
+get_event_data_payloads(StreamId, Events) ->
+    [Data || #{type := data,
+               stream_id := SId, payload := {data, Data}} <- Events,
+             SId == StreamId].
+
+connect_to_server(Addr, Port) ->
+    {ok, Sock} = gen_tcp:connect(Addr, Port,
+                                 [binary, {packet, 0}, {active, false}]),
+    CSocket = {gen_tcp, Sock},
+    Streams = chatterbox_h2_stream_set:new(client, CSocket, undefined, [], false),
+    {ok, #{sock => CSocket,
+           streams => Streams}}.
+
+handshake_as_if_exchanged_settings(ServierSideSendWindowSize,
+                                   #{streams := Streams}) ->
+    %% Simulate a handshake exchange of settings
+    %% We're a client in this scenario, so we'll first get
+    %% settings from the server side.
+    %% Simulate that the server side sends us (only) its initial window size.
+
+    %% For comparison, printouts in h2_connection when initiating a client
+    %% connection to a http2 implemented in go.
+    %%
+    %% First we receive settings from the go server, which was created with:
+    %%        s := grpc.NewServer(
+    %%                grpc.InitialConnWindowSize(10*1024*1024),
+    %%                grpc.InitialWindowSize(10*1024*1024),
+    %%        )
+    %% And we get:
+    %%   PS={settings,4096,1,unlimited,65535,16384,unlimited}
+    %%   Payload={settings,[{<<5>>,16384},{<<4>>,10485760}]}
+    %%     OldIWS=65535
+    %%     HTS=4096
+    %%     => {settings,4096,1,unlimited,10485760,16384,unlimited}
+    %%        Delta=10420225
+    %%
+    %% Then we get an ack for our own sent settings.
+    %% We had initially set this chatterbox application env variable:
+    %%   client_initial_window_size = 1024 * 1024 * 10
+    %% and this happens:
+    %%   Settings ACK:
+    %%     NewSettings (queued to get applied):
+    %%       {settings,4096,1,unlimited,65535,16384,unlimited}
+    %%     get_self_settings_locked returned:
+    %%       {settings,4096,1,unlimited,10485760,16384,unlimited}
+    %%     Delta = 10420225
+    %%     Max Concurrent = unlimited
+
+    #settings{initial_window_size=PeerOldIWS} = PeerSettings0 =
+        chatterbox_h2_stream_set:get_peer_settings_locked(Streams),
+    ServerDelta = ServierSideSendWindowSize - PeerOldIWS,
+    PeerSettings1 = PeerSettings0#settings{
+                      initial_window_size = ServierSideSendWindowSize},
+    chatterbox_h2_stream_set:update_peer_settings(Streams, PeerSettings1),
+    chatterbox_h2_stream_set:update_all_send_windows(ServerDelta, Streams),
+
+    %% Now simulate that we've sent our settings and gotten an ACK,
+    %% so we must now apply our sent settings.
+    #settings{initial_window_size=OurSentInitialWindowSize} = OurSettings0 =
+        chatterbox:settings(client),
+    ?assert(is_integer(OurSentInitialWindowSize), OurSettings0),
+    #settings{initial_window_size=OurOldIWS} =
+        chatterbox_h2_stream_set:get_self_settings_locked(Streams),
+    OurDelta = OurSentInitialWindowSize - OurOldIWS,
+    OurSettings1 = OurSettings0#settings{initial_window_size = OurSentInitialWindowSize},
+    chatterbox_h2_stream_set:update_self_settings(Streams, OurSettings1),
+    chatterbox_h2_stream_set:update_all_recv_windows(OurDelta, Streams),
+    ok.
+
+start_server() ->
+    Testcase = self(),
+    proc_lib:start(erlang, apply, [fun() -> init_tcp_server(Testcase) end, []]).
+
+simulate_window_update(N, 0=_StreamId, Streams, ServerInfo) ->
+    chatterbox_h2_stream_set:increment_socket_send_window(N, Streams),
+    save_event(ServerInfo, {socket_window_update, N}),
+    chatterbox_h2_stream_set:send_all_we_can(Streams);
+simulate_window_update(N, StreamId, Streams, ServerInfo) ->
+    save_event(ServerInfo, {stream_window_update, N, StreamId}),
+    chatterbox_h2_stream_set:send_what_we_can(
+      StreamId,
+      fun(Stream) ->
+              chatterbox_h2_stream_set:increment_send_window_size(N, Stream)
+      end, Streams).
+
+get_clear_events(#{server_pid := Pid}) ->
+    do_request(Pid, get_clear_events).
+
+save_event(#{server_pid := Pid}, Event) ->
+    do_request(Pid, {save_event, Event}).
+
+send_headers_and_data_from_client(Conn, StreamId, Body) ->
+    ok = send_headers(Conn, StreamId),
+    ok = send_body(Conn, StreamId, Body).
+
+send_headers(#{sock := Sock, streams := Streams}, StreamId) ->
+    Headers =
+        [
+         {<<":method">>, <<"GET">>},
+         {<<":path">>, <<"/index.html">>},
+         {<<":scheme">>, <<"https">>},
+         {<<":authority">>, <<"localhost:8080">>},
+         {<<"accept">>, <<"*/*">>},
+         {<<"accept-encoding">>, <<"gzip, deflate">>},
+         {<<"user-agent">>, <<"chattercli/0.0.1 :D">>}
+        ],
+    Stream = chatterbox_h2_stream_set:get(StreamId, Streams),
+    {_SelfSettings, PeerSettings} = chatterbox_h2_stream_set:get_settings(Streams),
+    {Lock, EncodeContext} = chatterbox_h2_stream_set:get_encode_context(Streams, Headers),
+    Complete = true,
+    {FramesToSend, NewContext} =
+        chatterbox_h2_frame_headers:to_frames(
+          chatterbox_h2_stream_set:stream_id(Stream),
+          Headers,
+          EncodeContext,
+          PeerSettings#settings.max_frame_size,
+          Complete
+         ),
+    chatterbox_sock:send(Sock, [chatterbox_h2_frame:to_binary(Frame) || Frame <- FramesToSend]),
+    chatterbox_h2_stream_set:release_encode_context(Streams, {Lock, NewContext}),
+    case chatterbox_h2_stream_set:pid(Stream) of
+        undefined ->
+            %% TODO: Should this be some kind of error?
+            ok;
+        Pid ->
+            chatterbox_h2_stream:send_event(Pid, {send_h, Headers})
+    end,
+    ok.
+
+send_body(#{streams := Streams}, StreamId, Body) ->
+    BodyComplete = true,
+    chatterbox_h2_stream_set:send_what_we_can(
+      StreamId,
+      fun(Stream) ->
+              OldBody = chatterbox_h2_stream_set:queued_data(Stream),
+              NewBody = case is_binary(OldBody) of
+                            true -> <<OldBody/binary, Body/binary>>;
+                            false -> Body
+                        end,
+              chatterbox_h2_stream_set:update_data_queue(NewBody, BodyComplete, Stream)
+      end, Streams),
+    ok.
+
+
+
+init_tcp_server(Testcase) ->
+    TcMRef = monitor(process, Testcase),
+    {ok, LSock} = gen_tcp:listen(0, [binary, {packet, 0}, {active, false}]),
+    {ok, {_Addr, Port}} = inet:sockname(LSock), % Addr will be {0,0,0,0}
+    proc_lib:init_ack({ok, #{listen_socket => LSock,
+                             server_pid => self(),
+                             server_addr => {127, 0, 0, 1},
+                             server_port => Port}}),
+    {ok, Sock} = gen_tcp:accept(LSock),
+    ct:pal("tcp_server: Client connected, Sock=~p", [Sock]),
+    loop_tcp_server(#{listen_socket => LSock,
+                      socket => {gen_tcp, Sock},
+                      decoder => hpack:new_context(),
+                      testcase => Testcase,
+                      testcase_mref => TcMRef,
+                      events => []}).
+
+loop_tcp_server(#{socket := Sock, listen_socket := LSock,
+                  testcase_mref := TcMRef, events := Events}=State) ->
+    case chatterbox_h2_frame:read(Sock, 50) of
+        {error, closed} ->
+            ct:pal("tcp_server: Socket remotely closed,~n"
+                   " events= ~p~n",
+                   [lists:reverse(Events)]),
+            gen_tcp:close(LSock),
+            ok;
+        {error, Reason} when Reason /= timeout ->
+            ct:pal("tcp_server: Failure to read from socket ~p: ~p,~n"
+                   " events= ~p~n",
+                   [Sock, Reason, lists:reverse(Events)]),
+            gen_tcp:close(LSock),
+            error({read_error,Reason});
+        {#frame_header{type=Type, stream_id=StreamId} = _Header, Payload} ->
+            ct:pal("tcp_server: Got H,P=~p,~p~n", [_Header, Payload]),
+            Event = #{type => pretty_type(Type),
+                      stream_id => StreamId,
+                      payload => Payload},
+            ?FUNCTION_NAME(State#{events := [Event | Events]});
+        {error, timeout} ->
+            receive
+                {request, From, Req} ->
+                    case Req of
+                        get_clear_events ->
+                            do_reply(From, lists:reverse(Events)),
+                            ?FUNCTION_NAME(State#{events := []});
+                        {save_event, Event} ->
+                            do_reply(From, ok),
+                            ?FUNCTION_NAME(State#{events := [Event | Events]});
+                        stop ->
+                            ct:pal("tcp_server: terminating on request~n"),
+                            gen_tcp:close(LSock),
+                            sock_close(Sock),
+                            do_reply(From, ok);
+                        X ->
+                            ct:pal("tcp_server: Unexpected request, "
+                                   "terminating:~n  ~p",
+                                   [X]),
+                            error({tcp_server_received_unexpected_request, X})
+                    end;
+                {'DOWN', TcMRef, _, _, _} ->
+                    ct:pal("tcp_server: test case terminated,~n"
+                           " events = ~p~n",
+                           [lists:reverse(Events)]),
+                    gen_tcp:close(LSock),
+                    sock_close(Sock),
+                    ok
+            after 0 -> ?FUNCTION_NAME(State)
+            end;
+        X ->
+            ct:pal("tcp_server: read from ~p returned unexpected value (terminating):~n"
+                   "  ~p~n"
+                   "  events = ~p~n",
+                   [Sock, X, lists:reverse(Events)]),
+            gen_tcp:close(LSock),
+            sock_close(Sock),
+            error({unexpected_read_value, X})
+    end.
+
+pretty_type(?DATA) -> data;
+pretty_type(?HEADERS) -> headers;
+pretty_type(?PRIORITY) -> priority;
+pretty_type(?RST_STREAM) -> rst_stream;
+pretty_type(?SETTINGS) -> settings;
+pretty_type(?PUSH_PROMISE) -> push_promise;
+pretty_type(?PING) -> ping;
+pretty_type(?GOAWAY) -> goaway;
+pretty_type(?WINDOW_UPDATE) -> window_update;
+pretty_type(?CONTINUATION) -> continuation;
+pretty_type(Unexpected) -> Unexpected.
+
+close_connection(#{sock := CSock}, #{server_pid := ServerPid}) ->
+    ct:pal("close_connection: stopping server~n"),
+    try do_request(ServerPid, stop)
+    catch _:_ -> ok
+    end,
+    ct:pal("close_connection: closing socket~n"),
+    sock_close(CSock),
+    ok.
+
+sock_close({gen_tcp, Sock}) ->
+    gen_tcp:close(Sock).
+
+do_request(Pid, Req) ->
+    MRef = monitor(process, Pid),
+    Pid ! {request, {MRef, self()}, Req},
+    receive
+        {reply, MRef, Reply} ->
+            demonitor(MRef, [flush]),
+            Reply;
+        {'DOWN', MRef, _, _, Reason} ->
+            error({terminated, Reason, Req})
+    end.
+
+do_reply({Ref, Pid}, Reply) ->
+    Pid ! {reply, Ref, Reply}.

--- a/test/http2s.erl
+++ b/test/http2s.erl
@@ -1,0 +1,92 @@
+-module(http2s).
+%%-behaviour(ranch_protocol).
+-include("../include/http2.hrl").
+
+%% Ranch callbacks
+-export([start_link/3]).
+-export([init/3]).
+
+start_link(Ref, Transport, Opts) ->
+    Pid = proc_lib:spawn_link(?MODULE, init, [Ref, Transport, Opts]),
+    {ok, Pid}.
+
+init(Ref, Transport, Opts) ->
+    {ok, Socket} = ranch:handshake(Ref),
+    Sock = {transport(Transport), Socket},
+    ct:pal("New incoming connection to the server."),
+    {ok, ?PREFACE} = chatterbox_sock:recv(Sock, byte_size(?PREFACE), 5000),
+    GarbageOnEnd = false,
+    Streams = chatterbox_h2_stream_set:new(server, Sock, undefined, [], GarbageOnEnd),
+    {CurrentSettings, _PeerSettings} = chatterbox_h2_stream_set:get_settings(Streams),
+    SettingsToSend = chatterbox:settings(server),
+    Bin = chatterbox_h2_frame_settings:send(CurrentSettings, SettingsToSend),
+    ok = chatterbox_sock:send(Sock, Bin),
+
+    DoDefer = proplists:get_bool(defer_data_until_rst_stream, Opts),
+    State0 = #{defer_until_rst_stream => DoDefer,
+               deferred_to_rst_stream => undefined},
+    receive_loop(Sock, hpack:new_context(), State0).
+
+transport(ranch_ssl) ->
+    ssl;
+transport(ranch_tcp) ->
+    gen_tcp;
+transport(tcp) ->
+    gen_tcp;
+transport(gen_tcp) ->
+    gen_tcp;
+transport(ssl) ->
+    ssl;
+transport(_Other) ->
+    error(unknown_protocol).
+
+receive_loop(Socket, Decoder,
+                #{defer_until_rst_stream := DoDefer,
+                  deferred_to_rst_stream := DeferredData}=State) ->
+    maybe
+        Frame={#frame_header{}=Header, _Payload} ?= chatterbox_h2_frame:read(Socket, infinity),
+        case Header#frame_header.type of
+            ?SETTINGS ->
+                if ?NOT_FLAG((Header#frame_header.flags), ?FLAG_ACK) ->
+                        ok = chatterbox_sock:send(Socket, chatterbox_h2_frame_settings:ack());
+                   true ->
+                        ok
+                end,
+                receive_loop(Socket, Decoder, State);
+            ?HEADERS ->
+                HeadersBin = chatterbox_h2_frame_headers:from_frames([Frame]),
+                {ok, {_Headers, NewDecoder}} = hpack:decode(HeadersBin, Decoder),
+                receive_loop(Socket, NewDecoder, State);
+            ?DATA ->
+                StreamId = Header#frame_header.stream_id,
+                Response = <<"response">>,
+                ToSend = {#frame_header{stream_id=StreamId, type=?DATA,
+                                        length=iolist_size(Response),
+                                        flags=?FLAG_END_STREAM},
+                          chatterbox_h2_frame_data:new(Response)},
+                if DoDefer ->
+                        State1 = State#{defer_until_rst_stream => false,
+                                        deferred_to_rst_stream => ToSend},
+                        receive_loop(Socket, Decoder, State1);
+                   not DoDefer ->
+                        ok = chatterbox_sock:send(Socket, chatterbox_h2_frame:to_binary(ToSend)),
+                        receive_loop(Socket, Decoder, State)
+                end;
+            ?RST_STREAM ->
+                if DeferredData == undefined ->
+                        ok;
+                   true ->
+                        ok = chatterbox_sock:send(Socket, chatterbox_h2_frame:to_binary(DeferredData))
+                end,
+                State1 = State#{deferred_to_rst_stream := undefined},
+                receive_loop(Socket, Decoder, State1);
+            ?WINDOW_UPDATE ->
+                receive_loop(Socket, Decoder, State);
+            Other ->
+                ct:pal("~p: got frame of type ~p~n frame: ~p",
+                       [?MODULE, Other, Frame]),
+                receive_loop(Socket, Decoder, State)
+        end
+    else
+        {error, closed} -> terminate_receive_loop
+    end.

--- a/test/http2s.erl
+++ b/test/http2s.erl
@@ -2,6 +2,8 @@
 %%-behaviour(ranch_protocol).
 -include("../include/http2.hrl").
 
+-export([is_stream/1]).
+
 %% Ranch callbacks
 -export([start_link/3]).
 -export([init/3]).
@@ -10,8 +12,12 @@ start_link(Ref, Transport, Opts) ->
     Pid = proc_lib:spawn_link(?MODULE, init, [Ref, Transport, Opts]),
     {ok, Pid}.
 
+is_stream(StreamId) ->
+    request({is_stream, StreamId}).
+
 init(Ref, Transport, Opts) ->
     {ok, Socket} = ranch:handshake(Ref),
+    register(?MODULE, self()),
     Sock = {transport(Transport), Socket},
     ct:pal("New incoming connection to the server."),
     {ok, ?PREFACE} = chatterbox_sock:recv(Sock, byte_size(?PREFACE), 5000),
@@ -23,8 +29,11 @@ init(Ref, Transport, Opts) ->
     ok = chatterbox_sock:send(Sock, Bin),
 
     DoDefer = proplists:get_bool(defer_data_until_rst_stream, Opts),
-    State0 = #{defer_until_rst_stream => DoDefer,
-               deferred_to_rst_stream => undefined},
+    NoEndStream = proplists:get_bool(no_end_stream, Opts),
+    State0 = #{no_end_stream => NoEndStream,
+               defer_until_rst_stream => DoDefer,
+               deferred_to_rst_stream => undefined,
+               streams => []},
     receive_loop(Sock, hpack:new_context(), State0).
 
 transport(ranch_ssl) ->
@@ -41,52 +50,97 @@ transport(_Other) ->
     error(unknown_protocol).
 
 receive_loop(Socket, Decoder,
-                #{defer_until_rst_stream := DoDefer,
-                  deferred_to_rst_stream := DeferredData}=State) ->
-    maybe
-        Frame={#frame_header{}=Header, _Payload} ?= chatterbox_h2_frame:read(Socket, infinity),
-        case Header#frame_header.type of
-            ?SETTINGS ->
-                if ?NOT_FLAG((Header#frame_header.flags), ?FLAG_ACK) ->
-                        ok = chatterbox_sock:send(Socket, chatterbox_h2_frame_settings:ack());
-                   true ->
-                        ok
-                end,
-                receive_loop(Socket, Decoder, State);
-            ?HEADERS ->
-                HeadersBin = chatterbox_h2_frame_headers:from_frames([Frame]),
-                {ok, {_Headers, NewDecoder}} = hpack:decode(HeadersBin, Decoder),
-                receive_loop(Socket, NewDecoder, State);
-            ?DATA ->
-                StreamId = Header#frame_header.stream_id,
-                Response = <<"response">>,
-                ToSend = {#frame_header{stream_id=StreamId, type=?DATA,
-                                        length=iolist_size(Response),
-                                        flags=?FLAG_END_STREAM},
-                          chatterbox_h2_frame_data:new(Response)},
-                if DoDefer ->
-                        State1 = State#{defer_until_rst_stream => false,
-                                        deferred_to_rst_stream => ToSend},
-                        receive_loop(Socket, Decoder, State1);
-                   not DoDefer ->
-                        ok = chatterbox_sock:send(Socket, chatterbox_h2_frame:to_binary(ToSend)),
-                        receive_loop(Socket, Decoder, State)
-                end;
-            ?RST_STREAM ->
-                if DeferredData == undefined ->
-                        ok;
-                   true ->
-                        ok = chatterbox_sock:send(Socket, chatterbox_h2_frame:to_binary(DeferredData))
-                end,
-                State1 = State#{deferred_to_rst_stream := undefined},
-                receive_loop(Socket, Decoder, State1);
-            ?WINDOW_UPDATE ->
-                receive_loop(Socket, Decoder, State);
-            Other ->
-                ct:pal("~p: got frame of type ~p~n frame: ~p",
-                       [?MODULE, Other, Frame]),
-                receive_loop(Socket, Decoder, State)
-        end
-    else
-        {error, closed} -> terminate_receive_loop
+             #{no_end_stream := NoEndStream,
+               defer_until_rst_stream := DoDefer,
+               deferred_to_rst_stream := DeferredData,
+               streams := Streams}=State) ->
+    case chatterbox_h2_frame:read(Socket, 10) of
+        Frame={#frame_header{stream_id = StreamId}=Header, _Payload} ->
+            Streams1 = lists:uniq([StreamId | Streams]),
+            State1 = State#{streams := Streams1},
+            case Header#frame_header.type of
+                ?SETTINGS ->
+                    if ?NOT_FLAG((Header#frame_header.flags), ?FLAG_ACK) ->
+                            ok = chatterbox_sock:send(Socket, chatterbox_h2_frame_settings:ack());
+                       true ->
+                            ok
+                    end,
+                    receive_loop(Socket, Decoder, State1);
+                ?HEADERS ->
+                    HeadersBin = chatterbox_h2_frame_headers:from_frames([Frame]),
+                    {ok, {_Headers, NewDecoder}} = hpack:decode(HeadersBin, Decoder),
+                    receive_loop(Socket, NewDecoder, State1);
+                ?DATA ->
+                    Response = <<"response">>,
+                    Flags = case NoEndStream of
+                                true -> 0;
+                                false -> ?FLAG_END_STREAM
+                            end,
+                    ToSend = {#frame_header{stream_id=StreamId, type=?DATA,
+                                            length=iolist_size(Response),
+                                            flags=Flags},
+                              chatterbox_h2_frame_data:new(Response)},
+                    if DoDefer ->
+                            State2 = State1#{defer_until_rst_stream => false,
+                                             deferred_to_rst_stream => ToSend},
+                            receive_loop(Socket, Decoder, State2);
+                       NoEndStream ->
+                            ok = chatterbox_sock:send(Socket, chatterbox_h2_frame:to_binary(ToSend)),
+                            receive_loop(Socket, Decoder, State1);
+                       not DoDefer ->
+                            ok = chatterbox_sock:send(Socket, chatterbox_h2_frame:to_binary(ToSend)),
+                            Streams2 = Streams1 -- [StreamId],
+                            State2 = State1#{streams := Streams2},
+                            receive_loop(Socket, Decoder, State2)
+                    end;
+                ?RST_STREAM ->
+                    if DeferredData == undefined ->
+                            ok;
+                       true ->
+                            ok = chatterbox_sock:send(Socket, chatterbox_h2_frame:to_binary(DeferredData))
+                    end,
+                    Streams2 = Streams1 -- [StreamId],
+                    State2 = State1#{streams := Streams2,
+                                     deferred_to_rst_stream := undefined},
+                    receive_loop(Socket, Decoder, State2);
+                ?WINDOW_UPDATE ->
+                    receive_loop(Socket, Decoder, State1);
+                Other ->
+                    ct:pal("~p: got frame of type ~p~n frame: ~p",
+                           [?MODULE, Other, Frame]),
+                    receive_loop(Socket, Decoder, State1)
+            end;
+        {error, closed} ->
+            terminate_receive_loop;
+        {error, timeout} ->
+            receive
+                {request, From, Req} ->
+                    case Req of
+                        {is_stream, StreamId} ->
+                            reply(From, lists:member(StreamId, Streams))
+                    end
+            after 0 ->
+                    ok
+            end,
+            receive_loop(Socket, Decoder, State)
     end.
+
+request(Req) ->
+    case whereis(?MODULE) of
+        P when is_pid(P) ->
+            MRef = monitor(process, P),
+            From = {MRef, self()},
+            P ! {request, From, Req},
+            receive
+                {resp, MRef, Resp} ->
+                    demonitor(MRef, [flush]),
+                    Resp;
+                {'DOWN', MRef, _, _, Reason} ->
+                    error({terminated, Reason})
+            end;
+        undefined ->
+            error({noproc, ?MODULE})
+    end.
+
+reply({Ref, Pid}, Resp) ->
+    Pid ! {resp, Ref, Resp}.


### PR DESCRIPTION
Hi, here are a stack of various fixes. These have been jointly developed by @JonathanArns, @mzeuner and me. They are largely independent of each other, except that they sometimes touch the same files/lines. Let me know if you want me to split them into different PRs. We are mainly using chatterbox via grpcbox as a client, and the commits address issues we've seen in somewhat intense signalling scenarios.

Here's a brief guide to the major changes:
* **Improve scheduling**: A stream could get starved sometimes when only part of the data could get sent. To see this happening, run the h2_stream_set_SUITE without the fix, in h2_stream_set. The test case will fail and print a list of events where it shows. The commit changes the order to be round-robin so it continues where it left off.
* **Bugfix tracking of last sent stream**: If sending ran out of socket window size, but there was still enough window size for the stream, and there was then a window update for the socket, then that stream was retried only later, after having wrapped all streams that needed sending. The commit changes so that the stream is retried earlier.
* **Handle incoming data on closed stream**: When a stream just closed, there could still be in-flight data for it. When that data arrived, there would be a crash. Avoid this crash by just ignoring the incoming data for the closed stream. This should be in line with the RFC 9113.

We have one more commit on our, but I'll write a separate issue about that.